### PR TITLE
refactor: move dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,30 +28,28 @@
     "top500",
     "websites"
   ],
-  "dependencies": {
-    "cheerio": "~1.2.0",
-    "got": "~11.8.6",
-    "lodash": "~4.18.1",
-    "p-any": "~3.0.0",
-    "p-cancelable": "2.1.1",
-    "papaparse": "~5.5.0",
-    "parse-decimal-number": "~1.0.0",
-    "write-json-file": "~4.3.0"
-  },
   "devDependencies": {
     "@commitlint/cli": "latest",
     "@commitlint/config-conventional": "latest",
     "ava": "7",
     "c8": "latest",
+    "cheerio": "~1.2.0",
     "ci-publish": "latest",
     "finepack": "latest",
     "git-authors-cli": "latest",
     "git-dirty": "latest",
     "github-generate-release": "latest",
+    "got": "~11.8.6",
+    "lodash": "~4.18.1",
     "nano-staged": "latest",
+    "p-any": "~3.0.0",
+    "p-cancelable": "2.1.1",
+    "papaparse": "~5.5.0",
+    "parse-decimal-number": "~1.0.0",
     "simple-git-hooks": "latest",
     "standard": "latest",
-    "standard-version": "latest"
+    "standard-version": "latest",
+    "write-json-file": "~4.3.0"
   },
   "engines": {
     "node": ">= 6"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Manifest-only change with no code edits; low risk unless downstream projects incorrectly relied on transitive installs of those packages from top-sites.
> 
> **Overview**
> Removes the **`dependencies`** section from `package.json` and reclassifies **`cheerio`**, **`got`**, **`lodash`**, **`p-any`**, **`p-cancelable`**, **`papaparse`**, **`parse-decimal-number`**, and **`write-json-file`** as **`devDependencies`** (same version ranges).
> 
> Consumers of the published package still get **`top-sites.json`** via **`main`**; those libraries are only used by **`scripts/postinstall`** during **`build`** / cron updates, so they are no longer installed as production transitive dependencies of **`top-sites`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f4a09bee35bb38df678e3d913c071730c57364e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->